### PR TITLE
Remove '-Wno-unused-const-variable'

### DIFF
--- a/CMakeCommon.cmake
+++ b/CMakeCommon.cmake
@@ -36,7 +36,6 @@ function (SetCompilerOptions target acVersion)
             -Wno-unused-parameter
             -Wno-unused-value
             -Wno-unused-private-field
-            -Wno-unused-but-set-variable
             -Wno-deprecated
             -Wno-unknown-pragmas
             -Wno-missing-braces


### PR DESCRIPTION
Certain clang versions give false errors with this error setting. 

See: error: unknown warning option '-Wno-unused-but-set-variable'; did you mean '-Wno-unused-const-variable'? [-Werror,-Wunknown-warning-option]

Jenkins jobs are failing because of this. The alternative is to update our clang version, but that's hardly a viable solution right now.