### PR TITLE
Rename release package

### DIFF
--- a/BuildAddOn.py
+++ b/BuildAddOn.py
@@ -1,4 +1,5 @@
 import argparse
+import cgi
 import json
 import os
 import pathlib
@@ -113,7 +114,10 @@ def PrepareDirectories (args, configData, platformName, addOnName, acVersionList
 
 
 def DownloadAndUnzip (url, dest):
-    fileName = url.split ('/')[-1]
+    remoteFile = urllib.request.urlopen (url)
+    contentDisposition = remoteFile.info ()['Content-Disposition']
+    _, params = cgi.parse_header (contentDisposition)
+    fileName = params["filename"]
     filePath = pathlib.Path (dest, fileName)
     if filePath.exists ():
         return

--- a/BuildAddOn.py
+++ b/BuildAddOn.py
@@ -281,18 +281,8 @@ def CopyResultToPackage (packageRootFolder, buildFolder, version, addOnName, pla
         ])
 
 
-# Extract the DevKit build numbers for each ACVersion
-def GetBuildNums (acVersionList, devKitFolderList):
-    result = {}
-    for version in acVersionList:
-        zipFile = list (devKitFolderList[version].glob ('*.zip'))[0]
-        result[version] = str (zipFile).split ('.')[-2]
-
-    return result
-
-
 # Zip packages
-def PackageAddOns (args, addOnName, platformName, acVersionList, languageList, buildFolder, packageRootFolder, buildNums):
+def PackageAddOns (args, addOnName, platformName, acVersionList, languageList, buildFolder, packageRootFolder):
     Check7ZInstallation ()
 
     for version in acVersionList:
@@ -306,7 +296,7 @@ def PackageAddOns (args, addOnName, platformName, acVersionList, languageList, b
         buildType = 'Release' if args.release else 'Daily'
         subprocess.call ([
             '7z', 'a',
-            str (packageRootFolder.parent / f'{addOnName}-{version}.{buildNums[version]}_{buildType}_{platformName}.zip'),
+            str (packageRootFolder.parent / f'{addOnName}-{version}_{buildType}_{platformName}.zip'),
             str (packageRootFolder / version / '*')
         ])
 
@@ -324,8 +314,7 @@ def Main ():
         BuildAddOns (args, configData, platformName, languageList, workspaceRootFolder, buildFolder, devKitFolderList)
 
         if args.package:
-            buildNums = GetBuildNums (acVersionList, devKitFolderList)
-            PackageAddOns (args, addOnName, platformName, acVersionList, languageList, buildFolder, packageRootFolder, buildNums)
+            PackageAddOns (args, addOnName, platformName, acVersionList, languageList, buildFolder, packageRootFolder)
 
         print ('Build succeeded!')
         sys.exit (0)

--- a/BuildAddOn.py
+++ b/BuildAddOn.py
@@ -290,7 +290,7 @@ def PackageAddOns (args, configData, addOnName, platformName, acVersionList, lan
             CopyResultToPackage (packageRootFolder, buildFolder, version, addOnName, platformName, 'RelWithDebInfo')
         
         buildType = 'Release' if args.release else 'Daily'
-        buildNum = configData["devKitLinks"][platformName][version].split('.')[-2]
+        buildNum = configData["devKitLinks"][platformName][version].split ('.')[-2]
 
         subprocess.call ([
             '7z', 'a',

--- a/BuildAddOn.py
+++ b/BuildAddOn.py
@@ -278,7 +278,7 @@ def CopyResultToPackage (packageRootFolder, buildFolder, version, addOnName, pla
 
 
 # Zip packages
-def PackageAddOns (args, addOnName, platformName, acVersionList, languageList, buildFolder, packageRootFolder):
+def PackageAddOns (args, configData, addOnName, platformName, acVersionList, languageList, buildFolder, packageRootFolder):
     Check7ZInstallation ()
 
     for version in acVersionList:
@@ -290,9 +290,11 @@ def PackageAddOns (args, addOnName, platformName, acVersionList, languageList, b
             CopyResultToPackage (packageRootFolder, buildFolder, version, addOnName, platformName, 'RelWithDebInfo')
         
         buildType = 'Release' if args.release else 'Daily'
+        buildNum = configData["devKitLinks"][platformName][version].split('.')[-2]
+
         subprocess.call ([
             '7z', 'a',
-            str (packageRootFolder.parent / f'{addOnName}-{version}_{buildType}_{platformName}.zip'),
+            str (packageRootFolder.parent / f'{addOnName}-{version}.{buildNum}_{buildType}_{platformName}.zip'),
             str (packageRootFolder / version / '*')
         ])
 
@@ -310,7 +312,7 @@ def Main ():
         BuildAddOns (args, configData, platformName, languageList, workspaceRootFolder, buildFolder, devKitFolderList)
 
         if args.package:
-            PackageAddOns (args, addOnName, platformName, acVersionList, languageList, buildFolder, packageRootFolder)
+            PackageAddOns (args, configData, addOnName, platformName, acVersionList, languageList, buildFolder, packageRootFolder)
 
         print ('Build succeeded!')
         sys.exit (0)


### PR DESCRIPTION
Added the build number into the created zip package name, to be known for compatibility reasons.