### PR TITLE
Update APIDevKitLinks.json

### DIFF
--- a/APIDevKitLinks.json
+++ b/APIDevKitLinks.json
@@ -1,12 +1,12 @@
 {
     "WIN": {
         "27": "https://github.com/GRAPHISOFT/archicad-api-devkit/releases/download/27.3001/API.Development.Kit.WIN.27.3001.zip",
-        "26": "https://github.com/GRAPHISOFT/archicad-api-devkit/releases/download/26.3000/API.Development.Kit.WIN.26.3000.zip",
+        "26": "https://github.com/GRAPHISOFT/archicad-api-devkit/releases/download/26.7000/API.Development.Kit.WIN.26.7000.zip",
         "25": "https://github.com/GRAPHISOFT/archicad-api-devkit/releases/download/25.3002/API.Development.Kit.WIN.25.3002.zip"
     },
     "MAC": {
         "27": "https://github.com/GRAPHISOFT/archicad-api-devkit/releases/download/27.3001/API.Development.Kit.MAC.27.3001.zip",
-        "26": "https://github.com/GRAPHISOFT/archicad-api-devkit/releases/download/26.3000/API.Development.Kit.MAC.26.3000.zip",
+        "26": "https://github.com/GRAPHISOFT/archicad-api-devkit/releases/download/26.7000/API.Development.Kit.MAC.26.7000.zip",
         "25": "https://github.com/GRAPHISOFT/archicad-api-devkit/releases/download/25.3002/API.Development.Kit.MAC.25.3002.zip"
     }
 }


### PR DESCRIPTION
Replaced AC26 devkits with build 7000 (from Update 5).