### PR TITLE
add Info.plist template + modify CMakeCommon to use it

### DIFF
--- a/AddOnInfo.plist.in
+++ b/AddOnInfo.plist.in
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>CFBundleDevelopmentRegion</key>
+		<string>English</string>
+		<key>CFBundleExecutable</key>
+		<string>@MACOSX_BUNDLE_EXECUTABLE_NAME@</string>
+		<key>CFBundleGetInfoString</key>
+		<string>@MACOSX_BUNDLE_INFO_STRING@</string>
+		<key>CFBundleIconFile</key>
+		<string>ArchiCADPlugin</string>
+		<key>CFBundleIdentifier</key>
+		<string>@MACOSX_BUNDLE_GUI_IDENTIFIER@</string>
+		<key>CFBundleInfoDictionaryVersion</key>
+		<string>6.0</string>
+		<key>CFBundleLongVersionString</key>
+		<string>@MACOSX_BUNDLE_LONG_VERSION_STRING@</string>
+		<key>CFBundleName</key>
+		<string>@MACOSX_BUNDLE_BUNDLE_NAME@</string>
+		<key>CFBundlePackageType</key>
+		<string>.APX</string>
+		<key>CFBundleSignature</key>
+		<string>GSAP</string>
+		<key>CFBundleShortVersionString</key>
+		<string>@MACOSX_BUNDLE_SHORT_VERSION_STRING@</string>
+		<key>CFBundleVersion</key>
+		<string>@MACOSX_BUNDLE_BUNDLE_VERSION@</string>
+		<key>NSHumanReadableCopyright</key>
+		<string>@MACOSX_BUNDLE_COPYRIGHT@</string>
+		<key>LSMinimumSystemVersion</key>
+		<string>@MINIMUM_SYSTEM_VERSION@</string>
+	</dict>
+</plist>


### PR DESCRIPTION
CMake has a built-in mechanism to handle Info.plist. Moreover, it may use a custom .plist template file where you can specify variables that are replaced during `configure_file()`.
As a side effect add-on developers no longer have to add an Info.plist file to RFIX.mac.
Most of the variables are filled in either from the targeted add-on (name, executable, GUI identifier), or an existing framework (LSMinimumSystemVersion, buildnum).
Using the buildnum also makes it easy to identify the devkit build used to create the add-on.
Tested with the ExampleAddOn, and with AC 26 & 27 devkits. 