### PR TITLE
ATEC-9459: Separate package logic from build configuration logic

### DIFF
--- a/BuildAddOn.py
+++ b/BuildAddOn.py
@@ -16,7 +16,7 @@ def ParseArguments ():
     parser = argparse.ArgumentParser ()
     parser.add_argument ('-c', '--configFile', dest = 'configFile', required = True, help = 'JSON Configuration file')
     parser.add_argument ('-v', '--acVersion', dest = 'acVersion', nargs = '+', type = str, required = False, help = 'Archicad version number list. Ex: 26 27')
-    parser.add_argument ('-b', '--buildConfig', dest = 'buildConfig', nargs = '+', type = str, required = False, help = 'Build configuration list. Ex: debug RELEASE RelWithDebInfo')
+    parser.add_argument ('-b', '--buildConfig', dest = 'buildConfig', nargs = '+', type = str, required = False, help = 'Build configuration list. Ex: Debug Release RelWithDebInfo')
     parser.add_argument ('-l', '--allLocalizedVersions', dest = 'allLocalizedVersions', required = False, action='store_true', help = 'Create localized release builds for all configured languages.')
     parser.add_argument ('-d', '--devKitPath', dest = 'devKitPath', type = str, required = False, help = 'Path to local APIDevKit')
     parser.add_argument ('-n', '--buildNum', dest = 'buildNum', type = str, required = False, help = 'Build number of local APIDevKit')

--- a/BuildAddOn.py
+++ b/BuildAddOn.py
@@ -16,9 +16,10 @@ def ParseArguments ():
     parser = argparse.ArgumentParser ()
     parser.add_argument ('-c', '--configFile', dest = 'configFile', required = True, help = 'JSON Configuration file')
     parser.add_argument ('-v', '--acVersion', dest = 'acVersion', nargs = '+', type = str, required = False, help = 'Archicad version number list. Ex: 26 27')
-    parser.add_argument ('-l', '--allLocalizedVersions', dest = 'allLocalizedVersions', required = False, action='store_true', help = 'Create localized release builds for all configured languages.' )
+    parser.add_argument ('-b', '--buildConfig', dest = 'buildConfig', nargs = '+', type = str, required = False, help = 'Build configuration list. Ex: debug RELEASE RelWithDebInfo')
+    parser.add_argument ('-l', '--allLocalizedVersions', dest = 'allLocalizedVersions', required = False, action='store_true', help = 'Create localized release builds for all configured languages.')
     parser.add_argument ('-d', '--devKitPath', dest = 'devKitPath', type = str, required = False, help = 'Path to local APIDevKit')
-    parser.add_argument ('-b', '--buildNum', dest = 'buildNum', type = str, required = False, help = 'Build number of local APIDevKit')
+    parser.add_argument ('-n', '--buildNum', dest = 'buildNum', type = str, required = False, help = 'Build number of local APIDevKit')
     parser.add_argument ('-p', '--package', dest = 'package', required = False, action='store_true', help = 'Create zip archive.')
     parser.add_argument ('-a', '--additionalCMakeParams', dest = 'additionalCMakeParams', nargs = '+', required = False, help = 'Add-On specific CMake parameter list of key=value pairs. Ex: var1=value1 var2="value 2"')
     parser.add_argument ('-q', '--quiet', dest = 'quiet', required = False, action='store_true', help = 'Less verbose cmake output.')
@@ -30,16 +31,31 @@ def ParseArguments ():
         if len (args.acVersion) != 1:
             raise Exception ('Only one Archicad version supported with local APIDevKit option!')
 
+    if args.buildConfig is not None:
+        for config in args.buildConfig:
+            configuration = ConfigToUpperCamelCase (config)
+            if configuration != 'Debug' and configuration != 'RelWithDebInfo' and configuration != 'Release':
+                raise Exception ('Invalid build configuration! Options are: Debug, Release, RelWithDebInfo')
+
     return args
+
+
+def GetPlatformName ():
+    return 'WIN' if platform.system () == 'Windows' else 'MAC' 
+
+
+def ConfigToUpperCamelCase (configuration):
+    if (configuration.lower () == 'debug'):
+        return 'Debug'
+    if (configuration.lower () == 'relwithdebinfo'):
+        return 'RelWithDebInfo'
+    if (configuration.lower () == 'release'):
+        return 'Release'
 
 
 def PrepareParameters (args):
     # Check platform operating system
-    platformName = None
-    if platform.system () == 'Windows':
-        platformName = 'WIN'
-    elif platform.system () == 'Darwin':
-        platformName = 'MAC'
+    platformName = GetPlatformName ()
 
     # Load DevKit download data
     devKitDataPath = pathlib.Path (__file__).absolute ().parent / 'APIDevKitLinks.json'
@@ -55,11 +71,17 @@ def PrepareParameters (args):
 
     addOnName = configData['addOnName']
     acVersionList = None
+    buildConfigList = None
 
     if args.acVersion:
         acVersionList = args.acVersion
     else:
         acVersionList = devKitData[platformName].keys ()
+
+    if args.buildConfig:
+        buildConfigList = [ConfigToUpperCamelCase (config) for config in args.buildConfig]
+    else:
+        buildConfigList = ["RelWithDebInfo"]    
 
     # Get needed language codes
     languageList = [configData['defaultLanguage'].upper ()]
@@ -84,15 +106,17 @@ def PrepareParameters (args):
                         raise Exception (f'Value not provided for {key}!')
                     additionalParams[key] = value
 
-    return [devKitData, platformName, addOnName, acVersionList, languageList, additionalParams]
+    return [devKitData, addOnName, buildConfigList, acVersionList, languageList, additionalParams]
 
 
-def PrepareDirectories (args, devKitData, platformName, addOnName, acVersionList):
+def PrepareDirectories (args, devKitData, addOnName, acVersionList):
     # Create directory for Build and Package
     workspaceRootFolder = pathlib.Path (__file__).parent.absolute ().parent.absolute ()
     buildFolder = workspaceRootFolder / 'Build'
     packageRootFolder = buildFolder / 'Package' / addOnName
     devKitFolderList = {}
+
+    platformName = GetPlatformName ()
 
     if not buildFolder.exists ():
         buildFolder.mkdir (parents=True)
@@ -108,10 +132,6 @@ def PrepareDirectories (args, devKitData, platformName, addOnName, acVersionList
             raise Exception (f'{devKitPath} is not a directory!')
         devKitFolderList[acVersionList[0]] = devKitPath
     else:
-        # For every ACVersion
-        # Check if APIDevKitLink is provided
-        # Create directory for APIDevKit
-        # Download APIDevKit
         for version in acVersionList:
             if version in devKitData[platformName]:
 
@@ -190,7 +210,7 @@ def GetProjectGenerationParams (workspaceRootFolder, buildPath, addOnName, platf
         projGenParams.extend (['-G', 'Xcode'])
 
     projGenParams.append (f'-DAC_VERSION={version}')
-    projGenParams.append (f'-DAC_ADDON_NAME={addOnName}')
+    projGenParams.append (f'-DAC_ADDON_NAME={addOnName}-{version}')
     projGenParams.append (f'-DAC_API_DEVKIT_DIR={str (devKitFolder / "Support")}')
     projGenParams.append (f'-DAC_ADDON_LANGUAGE={languageCode}')
 
@@ -232,20 +252,16 @@ def BuildAddOn (addOnName, platformName, additionalParams, workspaceRootFolder, 
         raise Exception ('Failed to build project!')
 
 
-def BuildAddOns (args, addOnName, platformName, languageList, additionalParams, workspaceRootFolder, buildFolder, devKitFolderList):
-    # At this point, devKitFolderList dictionary has all provided ACVersions as keys
-    # For every ACVersion
-    # If release, build Add-On for all languages with RelWithDebInfo configuration
-    # Else build Add-On with Debug and RelWithDebInfo configurations, without language specified
-    # In each case, if package creation is enabled, copy the .apx/.bundle files to the Package directory
+def BuildAddOns (args, addOnName, buildConfigList, languageList, additionalParams, workspaceRootFolder, buildFolder, devKitFolderList):
+    platformName = GetPlatformName ()
+
     try:
         for version in devKitFolderList:
             devKitFolder = devKitFolderList[version]
 
             for languageCode in languageList:
-                BuildAddOn (addOnName, platformName, additionalParams, workspaceRootFolder, buildFolder, devKitFolder, version, 'RelWithDebInfo', languageCode, args.quiet)
-                if args.package is False:
-                    BuildAddOn (addOnName, platformName, additionalParams, workspaceRootFolder, buildFolder, devKitFolder, version, 'Debug', languageCode, args.quiet)
+                for config in buildConfigList:
+                    BuildAddOn (addOnName, platformName, additionalParams, workspaceRootFolder, buildFolder, devKitFolder, version, config, languageCode, args.quiet)
 
     except Exception as e:
         raise e
@@ -259,7 +275,7 @@ def Check7ZInstallation ():
 
 
 def CopyResultToPackage (packageRootFolder, buildFolder, version, addOnName, platformName, configuration, languageCode):
-    packageFolder = packageRootFolder / version / languageCode
+    packageFolder = packageRootFolder / version / languageCode / configuration
     sourceFolder = buildFolder / addOnName / version / languageCode / configuration
 
     if not packageFolder.exists ():
@@ -267,19 +283,20 @@ def CopyResultToPackage (packageRootFolder, buildFolder, version, addOnName, pla
 
     if platformName == 'WIN':
         shutil.copy (
-            sourceFolder / f'{addOnName}.apx',
-            packageFolder / f'{addOnName}.apx',
+            sourceFolder / f'{addOnName}-{version}.apx',
+            packageFolder / f'{addOnName}-{version}.apx',
         )
-        shutil.copy (
-            sourceFolder / f'{addOnName}.pdb',
-            packageFolder / f'{addOnName}.pdb',
-        )
+        if configuration != 'Release':
+            shutil.copy (
+                sourceFolder / f'{addOnName}-{version}.pdb',
+                packageFolder / f'{addOnName}-{version}.pdb',
+            )
 
     elif platformName == 'MAC':
         subprocess.call ([
             'cp', '-R',
-            sourceFolder / f'{addOnName}.bundle',
-            packageFolder / f'{addOnName}.bundle'
+            sourceFolder / f'{addOnName}-{version}.bundle',
+            packageFolder / f'{addOnName}-{version}.bundle'
         ])
 
 
@@ -294,35 +311,38 @@ def GetDevKitVersion (args, devKitData, version, platformName):
 
 
 # Zip packages
-def PackageAddOns (args, devKitData, addOnName, platformName, acVersionList, languageList, buildFolder, packageRootFolder):
+def PackageAddOns (args, devKitData, addOnName, buildConfigList, acVersionList, languageList, buildFolder, packageRootFolder):
+    platformName = GetPlatformName ()
     Check7ZInstallation ()
 
     for version in acVersionList:
-        for languageCode in languageList:
-            CopyResultToPackage (packageRootFolder, buildFolder, version, addOnName, platformName, 'RelWithDebInfo', languageCode)
+        versionAndBuildNum = GetDevKitVersion (args, devKitData, version, platformName)
 
-            versionAndBuildNum = GetDevKitVersion (args, devKitData, version, platformName)
-            subprocess.call ([
-                '7z', 'a',
-                str (packageRootFolder.parent / version / f'{addOnName}-{versionAndBuildNum}_{platformName}_{languageCode}.zip'),
-                str (packageRootFolder / version / languageCode / '*')
-            ])
+        for languageCode in languageList:
+            for config in buildConfigList:
+                CopyResultToPackage (packageRootFolder, buildFolder, version, addOnName, platformName, config, languageCode)
+
+                subprocess.call ([
+                    '7z', 'a',
+                    str (packageRootFolder.parent / version / f'{addOnName}-{versionAndBuildNum}_{platformName}_{languageCode}_{config}.zip'),
+                    str (packageRootFolder / version / languageCode / config / '*')
+                ])
 
 
 def Main ():
     try:
         args = ParseArguments ()
 
-        [devKitData, platformName, addOnName, acVersionList, languageList, additionalParams] = PrepareParameters (args)
+        [devKitData, addOnName, buildConfigList, acVersionList, languageList, additionalParams] = PrepareParameters (args)
 
-        [workspaceRootFolder, buildFolder, packageRootFolder, devKitFolderList] = PrepareDirectories (args, devKitData, platformName, addOnName, acVersionList)
+        [workspaceRootFolder, buildFolder, packageRootFolder, devKitFolderList] = PrepareDirectories (args, devKitData, addOnName, acVersionList)
 
         os.chdir (workspaceRootFolder)
 
-        BuildAddOns (args, addOnName, platformName, languageList, additionalParams, workspaceRootFolder, buildFolder, devKitFolderList)
+        BuildAddOns (args, addOnName, buildConfigList, languageList, additionalParams, workspaceRootFolder, buildFolder, devKitFolderList)
 
         if args.package:
-            PackageAddOns (args, devKitData, addOnName, platformName, acVersionList, languageList, buildFolder, packageRootFolder)
+            PackageAddOns (args, devKitData, addOnName, buildConfigList, acVersionList, languageList, buildFolder, packageRootFolder)
 
         print ('Build succeeded!')
         sys.exit (0)

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ There is a configuration file that consists of an object containing key-value pa
 
 The repo includes a BuildAddOn.py python script, that handles the building of the Add-Ons. This script takes up to 9 arguments:
 
-- -c, --configFile (mandatory): path to the JSON configuration file.
-- -v, --acVersion (optional, but mandatory if --devKitPath is used): a list of Archicad version numbers, that the Add-On is built for. These versions must be present in the object keys of the APIDevKitLinks file. When not specified, the script takes all versions specified in the APIDevKitLinks file.
-- -b, --buildConfig (optional): list of Archicad build configurations. If not specified, defaults to RelWithDebInfo only. Ex: -b debug RELEASE RelWithDebInfo.
+- -c, --configFile (mandatory): Path to the JSON configuration file.
+- -v, --acVersion (optional, but mandatory if --devKitPath is used): A list of Archicad version numbers, that the Add-On is built for. These versions must be present in the object keys of the APIDevKitLinks file. When not specified, the script takes all versions specified in the APIDevKitLinks file.
+- -b, --buildConfig (optional): List of Archicad build configurations. If not specified, defaults to RelWithDebInfo only. Ex: -b debug RELEASE RelWithDebInfo.
 - -l, --allLocalizedVersions (optional): Toggles creating localized builds for all languages listed in the language object of the JSON configuration file. If not enabled, the configured defaultLanguage will be used.
-- -d, --devKitPath (optional): path to a single local APIDevKit folder. When this argument is used, only one Archicad version should be provided in the --acVersion list.
+- -d, --devKitPath (optional): Path to a single local APIDevKit folder. When this argument is used, only one Archicad version should be provided in the --acVersion list.
 - -n, --buildNum (optional, but mandatory if --devKitPath is used): Build number of the used local APIDevKit. Ex: -n 3001.
-- -p, --package (optional): toggles creating zip archive with the built Add-On files.
-- -a, --additionalCMakeParams (optional): a list of additional addon-specific CMake parameters as keys or key=value pairs. The build script will forward it to CMake. Ex: -a var1=value1 var2="value 2" var3.
-- -q, --quiet (optional): minimal / less verbose output from the build tool.
+- -p, --package (optional): Toggles creating zip archive with the built Add-On files.
+- -a, --additionalCMakeParams (optional): A list of additional AddOn-specific CMake parameters as keys or key=value pairs. The build script will forward it to CMake. Ex: -a var1=value1 var2="value 2" var3.
+- -q, --quiet (optional): Suppresses output of the build tool.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The repo includes a BuildAddOn.py python script, that handles the building of th
 
 - -c, --configFile (mandatory): Path to the JSON configuration file.
 - -v, --acVersion (optional, but mandatory if --devKitPath is used): A list of Archicad version numbers, that the Add-On is built for. These versions must be present in the object keys of the APIDevKitLinks file. When not specified, the script takes all versions specified in the APIDevKitLinks file.
-- -b, --buildConfig (optional): List of Archicad build configurations. If not specified, defaults to RelWithDebInfo only. Ex: -b debug RELEASE RelWithDebInfo.
+- -b, --buildConfig (optional): List of Archicad build configurations. If not specified, defaults to RelWithDebInfo only. Ex: -b Debug Release RelWithDebInfo.
 - -l, --allLocalizedVersions (optional): Toggles creating localized builds for all languages listed in the language object of the JSON configuration file. If not enabled, the configured defaultLanguage will be used.
 - -d, --devKitPath (optional): Path to a single local APIDevKit folder. When this argument is used, only one Archicad version should be provided in the --acVersion list.
 - -n, --buildNum (optional, but mandatory if --devKitPath is used): Build number of the used local APIDevKit. Ex: -n 3001.

--- a/README.md
+++ b/README.md
@@ -8,13 +8,14 @@ There is a configuration file that consists of an object containing key-value pa
 
 ## Build script
 
-The repo includes a BuildAddOn.py python script, that handles the building of the Add-Ons. This script takes up to 7 arguments:
+The repo includes a BuildAddOn.py python script, that handles the building of the Add-Ons. This script takes up to 9 arguments:
 
 - -c, --configFile (mandatory): path to the JSON configuration file.
 - -v, --acVersion (optional, but mandatory if --devKitPath is used): a list of Archicad version numbers, that the Add-On is built for. These versions must be present in the object keys of the APIDevKitLinks file. When not specified, the script takes all versions specified in the APIDevKitLinks file.
+- -b, --buildConfig (optional): list of Archicad build configurations. If not specified, defaults to RelWithDebInfo only. Ex: -b debug RELEASE RelWithDebInfo.
 - -l, --allLocalizedVersions (optional): Toggles creating localized builds for all languages listed in the language object of the JSON configuration file. If not enabled, the configured defaultLanguage will be used.
 - -d, --devKitPath (optional): path to a single local APIDevKit folder. When this argument is used, only one Archicad version should be provided in the --acVersion list.
-- -b, --buildNum (optional, but mandatory if --devKitPath is used): Build number of the used local APIDevKit. Ex: -b 3001.
+- -n, --buildNum (optional, but mandatory if --devKitPath is used): Build number of the used local APIDevKit. Ex: -n 3001.
 - -p, --package (optional): toggles creating zip archive with the built Add-On files.
 - -a, --additionalCMakeParams (optional): a list of additional addon-specific CMake parameters as keys or key=value pairs. The build script will forward it to CMake. Ex: -a var1=value1 var2="value 2" var3.
 - -q, --quiet (optional): minimal / less verbose output from the build tool.


### PR DESCRIPTION
- Separated packaging logic from build configuration logic
- - added new optional parameter for build configuration list, defaults to RelWithDebInfo
- Added AC version number to solution name
- Updated README accordingly