### PR TITLE
Use GSRoot Overridden Allocators Consistently

### DIFF
--- a/CMakeCommon.cmake
+++ b/CMakeCommon.cmake
@@ -222,11 +222,23 @@ function (GenerateAddOnProject target acVersion devKitDir addOnName addOnSources
     target_include_directories (${target} PUBLIC ${addOnSourcesFolder})
 
     # use GSRoot custom allocators consistently in the Add-On
-    target_precompile_headers(${target} 
-        PRIVATE 
-        ${devKitDir}/Modules/GSRoot/GSNew.hpp 
-        ${devKitDir}/Modules/GSRoot/GSMalloc.hpp
+    get_filename_component(new_hpp "${devKitDir}/Modules/GSRoot/GSNew.hpp" REALPATH)
+    get_filename_component(malloc_hpp "${devKitDir}/Modules/GSRoot/GSMalloc.hpp" REALPATH)
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+        target_compile_options(
+            "${target}" PRIVATE
+            "SHELL:/FI \"${new_hpp}\""
+            "SHELL:/FI \"${malloc_hpp}\""
         )
+    elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang\$")
+        target_compile_options(
+            "${target}" PRIVATE
+            "SHELL:-include \"${new_hpp}\""
+            "SHELL:-include \"${malloc_hpp}\""
+        )
+    else()
+        message(FATAL_ERROR "Unknown compiler ID. Please open an issue at https://github.com/GRAPHISOFT/archicad-addon-cmake-tools")
+    endif()
 
     LinkGSLibrariesToProject (${target} ${acVersion} ${devKitDir})
 

--- a/CMakeCommon.cmake
+++ b/CMakeCommon.cmake
@@ -221,6 +221,13 @@ function (GenerateAddOnProject target acVersion devKitDir addOnName addOnSources
     target_include_directories (${target} SYSTEM PUBLIC ${devKitDir}/Inc)
     target_include_directories (${target} PUBLIC ${addOnSourcesFolder})
 
+    # use GSRoot custom allocators consistently in the Add-On
+    target_precompile_headers(${target} 
+        PRIVATE 
+        ${devKitDir}/Modules/GSRoot/GSNew.hpp 
+        ${devKitDir}/Modules/GSRoot/GSMalloc.hpp
+        )
+
     LinkGSLibrariesToProject (${target} ${acVersion} ${devKitDir})
 
     set_source_files_properties (${AddOnSourceFiles} PROPERTIES LANGUAGE CXX)


### PR DESCRIPTION
Many API headers already include GSRoot.hpp (and thus GSNew and GSMalloc), but the headers have to be included everywhere to ensure that the Add-On consistently uses new/delete and malloc/free. This is especially important for the malloc/free override macros, which need to be present in all translation units.