### PR TITLE
ATEC-9902: Add version info support to Windows

### DIFF
--- a/VersionInfo.rc.in
+++ b/VersionInfo.rc.in
@@ -1,0 +1,48 @@
+#include <Windows.h>
+
+/* UTF-8 */
+#pragma code_page 65001
+
+#cmakedefine AC_ADDON_IS_RELEASE
+
+#ifdef AC_ADDON_IS_RELEASE
+#define PRERELEASE_FLAGS 0
+#else
+#define PRERELEASE_FLAGS VS_FF_PRIVATEBUILD|VS_FF_PRERELEASE
+#endif
+
+/* https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros */
+#ifdef _DEBUG
+#define DEBUG_FLAG VS_FF_DEBUG
+#else
+#define DEBUG_FLAG 0
+#endif
+
+/* https://learn.microsoft.com/en-us/windows/win32/menurc/versioninfo-resource */
+VS_VERSION_INFO VERSIONINFO
+	FILEVERSION @version_comma@
+	PRODUCTVERSION @version_comma@
+	FILEFLAGSMASK VS_FFI_FILEFLAGSMASK
+	FILEFLAGS (PRERELEASE_FLAGS|DEBUG_FLAG)
+	FILEOS VOS_NT_WINDOWS32
+	FILETYPE VFT_DLL
+	FILESUBTYPE VFT2_UNKNOWN
+BEGIN
+	/* https://learn.microsoft.com/en-us/windows/win32/menurc/stringfileinfo-block */
+	BLOCK "StringFileInfo"
+	BEGIN
+		BLOCK "040904b0"
+		BEGIN
+			VALUE "CompanyName", "@company@"
+			VALUE "FileVersion", "@version@"
+			VALUE "LegalCopyright", "@copyright@"
+			VALUE "OriginalFilename", "@addOnName@.apx"
+			VALUE "ProductVersion", "@version@"
+		END
+	END
+	/* https://learn.microsoft.com/en-us/windows/win32/menurc/varfileinfo-block */
+	BLOCK "VarFileInfo"
+	BEGIN
+		VALUE "Translation", 0x0409, 1200
+	END
+END


### PR DESCRIPTION
The embedded version information resource will not be available from the Properties context menu of the .apx file, however the resource is present regardless and can be read programmatically using the corresponding Win32 functions.