### PR TITLE
Pass `config.json` fields to code as defines

### DIFF
--- a/CMakeCommon.cmake
+++ b/CMakeCommon.cmake
@@ -121,7 +121,7 @@ function (parse_version inValue outList)
     endif ()
 endfunction ()
 
-function (generate_add_on_version_info)
+function (generate_add_on_version_info outSemver)
     parse_version ("${addOnVersion}" vers)
     if (NOT DEFINED vers)
         message (FATAL_ERROR "'${addOnVersion}' does not follow the '123' or '1.23' or '1.2.3' version format.")
@@ -129,6 +129,10 @@ function (generate_add_on_version_info)
     if (vers STREQUAL "0;0;0")
         message (WARNING "Addon version is '0.0.0', which is a placeholder version. Please change it in 'config.json'.")
     endif ()
+
+    list (JOIN vers . semver)
+    set ("${outSemver}" "${semver}" PARENT_SCOPE)
+
     string (TIMESTAMP copyright "Copyright © ${addOnCompanyName}, ${addOnCopyrightYear}")
 
     if (WIN32)
@@ -284,7 +288,13 @@ function (GenerateAddOnProject target acVersion devKitDir addOnSourcesFolder add
             LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/\$<CONFIG>"
         )
     endif ()
-    generate_add_on_version_info ()
+    generate_add_on_version_info (semver)
+    target_compile_definitions (
+        "${target}" PRIVATE
+        "ADDON_VERSION=\"${semver}\""
+        "ADDON_NAME=\"${addOnName}\""
+        "ADDON_LANGUAGE=\"${addOnLanguage}\""
+    )
 
     target_include_directories (${target} SYSTEM PUBLIC ${devKitDir}/Inc)
     target_include_directories (${target} PUBLIC ${addOnSourcesFolder})


### PR DESCRIPTION
The "version", "name" and the selected language are passed to the target created by "GenerateAddOnProject" as string literal defines. The respective defines are "ADDON_VERSION", "ADDON_NAME" and "ADDON_LANGUAGE".