### PR TITLE
Cmake based info plist

### DIFF
--- a/CMakeCommon.cmake
+++ b/CMakeCommon.cmake
@@ -60,7 +60,7 @@ function (SetCompilerOptions target acVersion)
 endfunction ()
 
 function (Codesign target)
-    if (NOT ${codesignIdentity} STREQUAL "")
+    if (NOT codesignIdentity STREQUAL "")
         # Path to the entitlements file
         set(ENTITLEMENTS_FILE "${CMAKE_SOURCE_DIR}/Tools/entitlements.plist")
 

--- a/CMakeCommon.cmake
+++ b/CMakeCommon.cmake
@@ -185,7 +185,7 @@ function (generate_add_on_version_info)
     endif ()
 endfunction ()
 
-function (GenerateAddOnProject target acVersion devKitDir addOnSourcesFolder addOnResourcesFolder addOnLanguage)
+function (GenerateAddOnProject target acVersion devKitDir addOnSourcesFolder addOnResourcesFolder addOnLanguage additionalIncludesFolder additionalLibraries)
     verify_api_devkit_folder ("${devKitDir}")
     if (NOT addOnLanguage IN_LIST addOnLanguages)
         message (FATAL_ERROR "Language '${addOnLanguage}' is not among the configured languages in config.json.")

--- a/CMakeCommon.cmake
+++ b/CMakeCommon.cmake
@@ -72,7 +72,7 @@ function (Codesign target)
         )
 
         # Ensure the application is signed after building
-        add_dependencies(codesign ${target})
+        add_dependencies(codesign "${target}")
     else ()
         message ("!! No codesigning identity is set in config.json. The add-on will not be signed.")
     endif ()

--- a/CMakeCommon.cmake
+++ b/CMakeCommon.cmake
@@ -288,6 +288,8 @@ function (GenerateAddOnProject target acVersion devKitDir addOnSourcesFolder add
 
     target_include_directories (${target} SYSTEM PUBLIC ${devKitDir}/Inc)
     target_include_directories (${target} PUBLIC ${addOnSourcesFolder})
+    target_include_directories (${target} SYSTEM PUBLIC ${additionalIncludesFolder})
+    target_link_libraries (${target} "${CMAKE_CURRENT_LIST_DIR}/${additionalLibraries}")
 
     # use GSRoot custom allocators consistently in the Add-On
     get_filename_component(new_hpp "${devKitDir}/Modules/GSRoot/GSNew.hpp" REALPATH)

--- a/CMakeCommon.cmake
+++ b/CMakeCommon.cmake
@@ -68,6 +68,7 @@ function (Codesign target)
         add_custom_target(codesign ALL
             COMMAND codesign --deep --force -vvv --timestamp --options runtime --preserve-metadata=identifier,entitlements,flag --sign "${codesignIdentity}" --entitlements "${ENTITLEMENTS_FILE}" $<TARGET_BUNDLE_DIR:${target}>
             COMMENT "Codesigning the add-on"
+            VERBATIM
         )
 
         # Ensure the application is signed after building

--- a/entitlements.plist
+++ b/entitlements.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+	<key>com.apple.security.get-task-allow</key>
+	<true/>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
I've added codesigning support for Mac add-ons. The code signing identity can be added to `config.json`.
Also, additional include directories and libraries are now supported.