### PR TITLE
Changed the MSVC runtime library from a local to a global variable

### DIFF
--- a/CMakeCommon.cmake
+++ b/CMakeCommon.cmake
@@ -2,7 +2,7 @@ function (SetGlobalCompilerDefinitions acVersion)
 
     if (WIN32)
         add_definitions (-DUNICODE -D_UNICODE -D_ITERATOR_DEBUG_LEVEL=0)
-        set (CMAKE_MSVC_RUNTIME_LIBRARY MultiThreadedDLL PARENT_SCOPE)
+        set (CMAKE_MSVC_RUNTIME_LIBRARY MultiThreadedDLL CACHE STRING "" FORCE)
     else ()
         add_definitions (-Dmacintosh=1)
         if (${acVersion} GREATER_EQUAL 26)


### PR DESCRIPTION
Hi!,
I accidentally happened to stumble upon a tiny issue where the `CMAKE_MSVC_RUNTIME_LIBRARY` variable, used by MSVC for initializing the `MSVC_RUNTIME_LIBRARY` target property, was set in the parent scope instead of as a cache variable. The consequence of this is that this function that sets "global" compiler definitions, will only do so correctly if called from the global scope.

Consider the case where someone would like to add some additional global options to their project. In those cases doing something like this could make sense:
```cmake
function (set_custom_global_compile_definitions)
  SetGlobalCompilerDefinitions (28)
  
  # Popular issue about missing Threads module on Mac:
  # https://stackoverflow.com/questions/54587052/cmake-on-mac-could-not-find-threads-missing-threads-found
  if (APPLE)
    set(CMAKE_THREAD_LIBS_INIT "-lpthread")
    set(CMAKE_HAVE_THREADS_LIBRARY 1)
    set(CMAKE_USE_WIN32_THREADS_INIT 0)
    set(CMAKE_USE_PTHREADS_INIT 1)
    set(THREADS_PREFER_PTHREAD_FLAG ON)
  endif ()
endfunction ()
```
However, calling `set_custom_global_compile_definitions` would now set `CMAKE_MSVC_RUNTIME_LIBRARY` in `set_custom_global_compile_definitions`'s scope instead of the probably expected global scope.