### PR TITLE
JSON resource support

### DIFF
--- a/CMakeCommon.cmake
+++ b/CMakeCommon.cmake
@@ -260,7 +260,7 @@ function (GenerateAddOnProject target acVersion devKitDir addOnSourcesFolder add
                 "${AddOnResourcesFolderAbsolute}"
                 "${ResourceObjectsDir}"
                 "${ResourceObjectsDir}/${addOnName}.res"
-                "${permissiveLocalizationArgument}"
+                ${permissiveLocalizationArgument}
             COMMAND ${CMAKE_COMMAND} -E touch ${ResourceStampFile}
         )
     else ()
@@ -278,7 +278,7 @@ function (GenerateAddOnProject target acVersion devKitDir addOnSourcesFolder add
                 "${AddOnResourcesFolderAbsolute}"
                 "${ResourceObjectsDir}"
                 "${CMAKE_BINARY_DIR}/$<CONFIG>/${addOnName}.bundle/Contents/Resources"
-                "${permissiveLocalizationArgument}"
+                ${permissiveLocalizationArgument}
             COMMAND ${CMAKE_COMMAND} -E copy "${devKitDir}/Inc/PkgInfo" "${CMAKE_BINARY_DIR}/$<CONFIG>/${addOnName}.bundle/Contents/PkgInfo"
             COMMAND ${CMAKE_COMMAND} -E touch ${ResourceStampFile}
         )

--- a/CMakeCommon.cmake
+++ b/CMakeCommon.cmake
@@ -218,7 +218,7 @@ function (GenerateAddOnProject target acVersion devKitDir addOnSourcesFolder add
         )
     endif ()
 
-    if (${acVersion} GREATER_EQUAL 30)
+    if (acVersion GREATER_EQUAL "30")
         file (GLOB AddOnJSONResourceFiles CONFIGURE_DEPENDS
             ${addOnResourcesFolder}/R${addOnDefaultLanguage}/*.json
             ${addOnResourcesFolder}/RFIX/*.json
@@ -230,7 +230,7 @@ function (GenerateAddOnProject target acVersion devKitDir addOnSourcesFolder add
     endif ()
 
     set (minimumPython3Version "3.8")
-    if (AddOnJSONResourceFiles)
+    if (NOT AddOnJSONResourceFiles STREQUAL "")
         set (minimumPython3Version "3.10")
     endif ()
 

--- a/CompileResources.py
+++ b/CompileResources.py
@@ -92,13 +92,24 @@ class ResourceCompiler (object):
         else:
             assert False, 'Unsupported platform: ' + platform.system ()
 
-        nativeResCreationResult = subprocess.call ([
+        jsonPartsDir = os.path.join (self.resourceObjectsPath, 'JsonParts')
+
+        if not os.path.exists (jsonPartsDir):
+            os.makedirs (jsonPartsDir, exist_ok=True)
+
+        nativeResCreationCommand = [
             sys.executable,
             os.path.join (jsonResourceProcessorPath, 'GSCreateNativeResourceFromJSON.py'),
             '-i', translatedJsonPath,
-            '-o', os.path.join (self.resourceObjectsPath, os.path.basename (jsonFilePath) + self.nativeResourceFileExtension),
+            '-o', os.path.join (jsonPartsDir, os.path.basename (jsonFilePath) + self.nativeResourceFileExtension),
             '-d', self.GetPlatformDefine (),
-        ], env=envForJson)
+        ]
+        if not localized:
+            imageResourcesFolder = os.path.join (self.resourcesPath, 'RFIX', 'Images')
+            nativeResCreationCommand.extend ([ '-p', imageResourcesFolder ])
+
+        nativeResCreationResult = subprocess.call (nativeResCreationCommand, env=envForJson)
+
         assert nativeResCreationResult == 0, 'Native resource creation command failed: ' + translatedJsonPath
 
         postCheckersCommand = [

--- a/CompileResources.py
+++ b/CompileResources.py
@@ -7,13 +7,17 @@ import codecs
 import argparse
 
 class ResourceCompiler (object):
-    def __init__ (self, devKitPath, languageCode, sourcesPath, resourcesPath, resourceObjectsPath):
+    def __init__ (self, devKitPath, addonName, languageCode, defaultLanguageCode, sourcesPath, resourcesPath, resourceObjectsPath, permissiveLocalization):
         self.devKitPath = devKitPath
+        self.addonName = addonName
         self.languageCode = languageCode
+        self.defaultLanguageCode = defaultLanguageCode
         self.sourcesPath = sourcesPath
         self.resourcesPath = resourcesPath
         self.resourceObjectsPath = resourceObjectsPath
+        self.permissiveLocalization = permissiveLocalization
         self.resConvPath = None
+        self.nativeResourceFileExtension = None
         
     def IsValid (self):
         if self.resConvPath == None:
@@ -22,26 +26,117 @@ class ResourceCompiler (object):
             return False
         return True
 
-    def GetPrecompiledResourceFilePath (self, grcFilePath):
+    def GetPrecompiledGRCResourceFilePath (self, grcFilePath):
         grcFileName = os.path.split (grcFilePath)[1]
         return os.path.join (self.resourceObjectsPath, grcFileName + '.i')
+
+    def CompileJSONResourceFile (self, jsonFilePath, localized):
+        jsonResourceProcessorPath = os.path.join (self.devKitPath, 'Tools', 'JSONResourceProcessor')
+        schemaValidationResult = subprocess.call ([
+            sys.executable,
+            os.path.join (jsonResourceProcessorPath, 'SchemaValidator.py'),
+            '-i', jsonFilePath,
+            '-o', os.path.join (self.resourceObjectsPath, os.path.basename (jsonFilePath) + '.valid'),
+            '--schemaFolder', os.path.join (self.devKitPath, 'Tools', 'SchemaFiles'),
+        ])
+        assert schemaValidationResult == 0, 'JSON Schema validation command failed: ' + jsonFilePath
+
+        translatedJsonPath = jsonFilePath
+
+        if localized:
+            xliffFileToTranslateWith = None
+            if self.languageCode == self.defaultLanguageCode:
+                xliffFileToTranslateWith = os.path.join (self.resourcesPath, 'R' + self.defaultLanguageCode, self.addonName + '.xlf')
+            else:
+                childXliffPath = os.path.join (self.resourcesPath, 'ResourceLibrary', self.languageCode, 'XLF', self.addonName + '.xlf')
+                parentTxtPath = os.path.join (self.resourcesPath, 'ResourceLibrary', self.languageCode, 'XLF', '_parent.txt')
+                if os.path.exists (parentTxtPath):
+                    parentLanguageCode = codecs.open (parentTxtPath, 'r', 'utf-8').read ().strip ()
+                    parentXliffPath = os.path.join (self.resourcesPath, 'ResourceLibrary', parentLanguageCode, 'XLF', self.addonName + '.xlf')
+                    mergedXliffOutputPath = os.path.join (self.resourceObjectsPath, self.addonName + '.merged.xlf')
+                    mergeParentChildXliffResult = subprocess.call ([
+                        sys.executable,
+                        os.path.join (jsonResourceProcessorPath, 'MergeParentChildXliff.py'),
+                        '--childXliff', childXliffPath,
+                        '--parentXliff', parentXliffPath,
+                        '-o', mergedXliffOutputPath
+                    ])
+                    assert mergeParentChildXliffResult == 0, 'Merge parent child XLIFF command failed: ' +  jsonFilePath
+                    xliffFileToTranslateWith = mergedXliffOutputPath
+                else:
+                    xliffFileToTranslateWith = childXliffPath
+
+            translatedJsonPath = os.path.join (self.resourceObjectsPath, os.path.basename (jsonFilePath) + '.translated')
+            xliffTranslationCommand = [
+                sys.executable,
+                os.path.join (jsonResourceProcessorPath, 'XliffJsonTranslator.py'),
+                '-i', jsonFilePath,
+                '-m', self.addonName,
+                '-d', xliffFileToTranslateWith,
+                '-o', translatedJsonPath,
+            ]
+            if self.permissiveLocalization:
+                xliffTranslationCommand.append ('--permissive')
+            xliffTranslationResult = subprocess.call (xliffTranslationCommand)
+            assert xliffTranslationResult == 0, 'XLIFF translation command failed: ' +  jsonFilePath
+
+        envForJson = os.environ.copy ()
+        if platform.system () == 'Windows':
+            dllFolder = os.path.join (jsonResourceProcessorPath, 'dlls')
+            envForJson['PATH'] = str (dllFolder) + os.pathsep + envForJson['PATH']
+        elif platform.system () == 'Darwin':
+            if platform.processor () == 'arm':
+                envForJson['DYLD_FALLBACK_LIBRARY_PATH'] = os.path.join (jsonResourceProcessorPath, 'dylibs_ARM')
+            else:
+                envForJson['DYLD_FALLBACK_LIBRARY_PATH'] = os.path.join (jsonResourceProcessorPath, 'dylibs')
+        else:
+            assert False, 'Unsupported platform: ' + platform.system ()
+
+        nativeResCreationResult = subprocess.call ([
+            sys.executable,
+            os.path.join (jsonResourceProcessorPath, 'GSCreateNativeResourceFromJSON.py'),
+            '-i', translatedJsonPath,
+            '-o', os.path.join (self.resourceObjectsPath, os.path.basename (jsonFilePath) + self.nativeResourceFileExtension),
+            '-d', self.GetPlatformDefine (),
+        ], env=envForJson)
+        assert nativeResCreationResult == 0, 'Native resource creation command failed: ' + translatedJsonPath
+
+        postCheckersCommand = [
+            sys.executable,
+            os.path.join (jsonResourceProcessorPath, 'RunPostCheckers.py'),
+            '-i', jsonFilePath,
+            '-o', os.path.join (self.resourceObjectsPath, os.path.basename (jsonFilePath) + '.postcheck'),
+        ]
+        if localized:
+            postCheckersCommand.append ('--localized')
+        postCheckersResult = subprocess.call (postCheckersCommand)
+        assert postCheckersResult == 0, 'Post-checkers command failed: ' + jsonFilePath
 
     def CompileLocalizedResources (self):
         locResourcesFolder = os.path.join (self.resourcesPath, 'R' + self.languageCode)
         grcFiles = self.CollectFilesFromFolderWithExtension (locResourcesFolder, '.grc')
         for grcFilePath in grcFiles:
-            assert self.CompileResourceFile (grcFilePath), 'Failed to compile resource: ' + grcFilePath
+            assert self.CompileGRCResourceFile (grcFilePath), 'Failed to compile resource: ' + grcFilePath
+
+        locResourcesFolderDefault = os.path.join (self.resourcesPath, 'R' + self.defaultLanguageCode)
+        jsonFiles = self.CollectFilesFromFolderWithExtension (locResourcesFolderDefault, '.json')
+        for jsonFilePath in jsonFiles:
+            self.CompileJSONResourceFile (jsonFilePath, localized=True)
 
     def CompileFixResources (self):
         fixResourcesFolder = os.path.join (self.resourcesPath, 'RFIX')
         grcFiles = self.CollectFilesFromFolderWithExtension (fixResourcesFolder, '.grc')
         for grcFilePath in grcFiles:
-            assert self.CompileResourceFile (grcFilePath), 'Failed to compile resource: ' + grcFilePath
+            assert self.CompileGRCResourceFile (grcFilePath), 'Failed to compile resource: ' + grcFilePath
 
-    def RunResConv (self, platformSign, codepage, inputFilePath, nativeResourceFileExtenion):
+        jsonFiles = self.CollectFilesFromFolderWithExtension (fixResourcesFolder, '.json')
+        for jsonFilePath in jsonFiles:
+            self.CompileJSONResourceFile (jsonFilePath, localized=False)
+
+    def RunResConv (self, platformSign, codepage, inputFilePath):
         imageResourcesFolder = os.path.join (self.resourcesPath, 'RFIX', 'Images')
         inputFileBaseName = os.path.splitext (os.path.split (inputFilePath)[1])[0]
-        nativeResourceFilePath = os.path.join (self.resourceObjectsPath, inputFileBaseName + nativeResourceFileExtenion)
+        nativeResourceFilePath = os.path.join (self.resourceObjectsPath, inputFileBaseName + self.nativeResourceFileExtension)
         result = subprocess.call ([
             self.resConvPath,
             '-m', 'r',                        # resource compile mode
@@ -58,6 +153,8 @@ class ResourceCompiler (object):
 
     def CollectFilesFromFolderWithExtension (self, folderPath, extension):
         result = []
+        if not os.path.exists (folderPath):
+            return result
         for fileName in os.listdir (folderPath):
             fileExtension = os.path.splitext (fileName)[1]
             if fileExtension.lower () == extension.lower ():
@@ -66,12 +163,16 @@ class ResourceCompiler (object):
         return result
 
 class WinResourceCompiler (ResourceCompiler):
-    def __init__ (self, devKitPath, languageCode, sourcesPath, resourcesPath, resourceObjectsPath):
-        super (WinResourceCompiler, self).__init__ (devKitPath, languageCode, sourcesPath, resourcesPath, resourceObjectsPath)
+    def __init__ (self, devKitPath, addonName, languageCode, defaultLanguageCode, sourcesPath, resourcesPath, resourceObjectsPath, permissiveLocalization):
+        super (WinResourceCompiler, self).__init__ (devKitPath, addonName, languageCode, defaultLanguageCode, sourcesPath, resourcesPath, resourceObjectsPath, permissiveLocalization)
         self.resConvPath = os.path.join (devKitPath, 'Tools', 'Win', 'ResConv.exe')
+        self.nativeResourceFileExtension = '.rc2'
 
-    def PrecompileResourceFile (self, grcFilePath):
-        precompiledGrcFilePath = self.GetPrecompiledResourceFilePath (grcFilePath)
+    def GetPlatformDefine (self):
+        return 'WINDOWS'
+
+    def PrecompileGRCResourceFile (self, grcFilePath):
+        precompiledGrcFilePath = self.GetPrecompiledGRCResourceFilePath (grcFilePath)
         result = subprocess.call ([
             'cl',
             '/nologo',
@@ -82,7 +183,7 @@ class WinResourceCompiler (ResourceCompiler):
             '/I', os.path.join (self.devKitPath, 'Modules', 'DGLib'),
             '/I', self.sourcesPath,
             '/I', self.resourceObjectsPath,
-            '/DWINDOWS',
+            '/D' + self.GetPlatformDefine (),
             '/source-charset:utf-8',
             '/execution-charset:utf-8',
             '/Fi{}'.format (precompiledGrcFilePath),
@@ -91,9 +192,9 @@ class WinResourceCompiler (ResourceCompiler):
         assert result == 0, 'Failed to precompile resource ' + grcFilePath
         return precompiledGrcFilePath
 
-    def CompileResourceFile (self, grcFilePath):
-        precompiledGrcFilePath = self.PrecompileResourceFile (grcFilePath)
-        return self.RunResConv ('W', '1252', precompiledGrcFilePath, '.rc2')
+    def CompileGRCResourceFile (self, grcFilePath):
+        precompiledGrcFilePath = self.PrecompileGRCResourceFile (grcFilePath)
+        return self.RunResConv ('W', '1252', precompiledGrcFilePath)
 
     def GetNativeResourceFile (self):
         defaultNativeResourceFile = os.path.join (self.resourcesPath, 'RFIX.win', 'AddOnMain.rc2')
@@ -119,18 +220,22 @@ class WinResourceCompiler (ResourceCompiler):
         assert result == 0, 'Failed to compile native resource ' + nativeResourceFile
 
 class MacResourceCompiler (ResourceCompiler):
-    def __init__ (self, devKitPath, languageCode, sourcesPath, resourcesPath, resourceObjectsPath):
-        super (MacResourceCompiler, self).__init__ (devKitPath, languageCode, sourcesPath, resourcesPath, resourceObjectsPath)
+    def __init__ (self, devKitPath, addonName, languageCode, defaultLanguageCode, sourcesPath, resourcesPath, resourceObjectsPath, permissiveLocalization):
+        super (MacResourceCompiler, self).__init__ (devKitPath, addonName, languageCode, defaultLanguageCode, sourcesPath, resourcesPath, resourceObjectsPath, permissiveLocalization)
         self.resConvPath = os.path.join (devKitPath, 'Tools', 'OSX', 'ResConv')
+        self.nativeResourceFileExtension = '.ro'
 
-    def PrecompileResourceFile (self, grcFilePath):
-        precompiledGrcFilePath = self.GetPrecompiledResourceFilePath (grcFilePath)
+    def GetPlatformDefine (self):
+        return 'macintosh'
+
+    def PrecompileGRCResourceFile (self, grcFilePath):
+        precompiledGrcFilePath = self.GetPrecompiledGRCResourceFilePath (grcFilePath)
         result = subprocess.call ([
             'clang',
             '-x', 'c++',
             '-E',
             '-P',
-            '-Dmacintosh',
+            '-D' + self.GetPlatformDefine (),
             '-I', os.path.join (self.devKitPath, 'Inc'),
             '-I', os.path.join (self.devKitPath, 'Modules', 'DGLib'),
             '-I', self.sourcesPath,
@@ -141,9 +246,9 @@ class MacResourceCompiler (ResourceCompiler):
         assert result == 0, 'Failed to precompile resource ' + grcFilePath
         return precompiledGrcFilePath
 
-    def CompileResourceFile (self, grcFilePath):
-        precompiledGrcFilePath = self.PrecompileResourceFile (grcFilePath)
-        return self.RunResConv ('M', 'utf16', precompiledGrcFilePath, '.ro')
+    def CompileGRCResourceFile (self, grcFilePath):
+        precompiledGrcFilePath = self.PrecompileGRCResourceFile (grcFilePath)
+        return self.RunResConv ('M', 'utf16', precompiledGrcFilePath)
 
     def CompileNativeResource (self, resultResourcePath):
         resultLocalizedResourcePath = os.path.join (resultResourcePath, 'English.lproj')
@@ -166,30 +271,36 @@ class MacResourceCompiler (ResourceCompiler):
 
 def Main (argv):
     parser = argparse.ArgumentParser (description = 'Archicad Add-On Resource Compiler.')
+    parser.add_argument ('addonName', help = 'Name of the Add-On.')
     parser.add_argument ('languageCode', help = 'Language code of the Add-On.')
+    parser.add_argument ('defaultLanguageCode', help = 'Default language code of the Add-On.')
     parser.add_argument ('devKitPath', help = 'Path of the Archicad Development Kit.')
     parser.add_argument ('sourcesPath', help = 'Path of the sources folder of the Add-On.')
     parser.add_argument ('resourcesPath', help = 'Path of the resources folder of the Add-On.')
     parser.add_argument ('resourceObjectsPath', help = 'Path of the folder to build resource objects.')
     parser.add_argument ('resultResourcePath', help = 'Path of the resulting resource.')
+    parser.add_argument ('--permissiveLocalization', action='store_true', help = 'Enable permissive localization mode.', default = False)
     args = parser.parse_args ()
 
     currentDir = os.path.dirname (os.path.abspath (__file__))
     os.chdir (currentDir)
 
+    addonName = args.addonName
     languageCode = args.languageCode
+    defaultLanguageCode = args.defaultLanguageCode
     devKitPath = os.path.abspath (args.devKitPath)
     sourcesPath = os.path.abspath (args.sourcesPath)
     resourcesPath = os.path.abspath (args.resourcesPath)
     resourceObjectsPath = os.path.abspath (args.resourceObjectsPath)
     resultResourcePath = os.path.abspath (args.resultResourcePath)
+    permissiveLocalization = args.permissiveLocalization
 
     resourceCompiler = None
     system = platform.system ()
     if system == 'Windows':
-        resourceCompiler = WinResourceCompiler (devKitPath, languageCode, sourcesPath, resourcesPath, resourceObjectsPath)
+        resourceCompiler = WinResourceCompiler (devKitPath, addonName, languageCode, defaultLanguageCode, sourcesPath, resourcesPath, resourceObjectsPath, permissiveLocalization)
     elif system == 'Darwin':
-        resourceCompiler = MacResourceCompiler (devKitPath, languageCode, sourcesPath, resourcesPath, resourceObjectsPath)
+        resourceCompiler = MacResourceCompiler (devKitPath, addonName, languageCode, defaultLanguageCode, sourcesPath, resourcesPath, resourceObjectsPath, permissiveLocalization)
 
     assert resourceCompiler, 'Platform is not supported'
     assert resourceCompiler.IsValid (), 'Invalid resource compiler'


### PR DESCRIPTION
This PR adds support for using JSON resources with the upcoming InhouseAPIDevKit. JSON resource compilation is very similar to the way it is done in JAM, the same python scripts will be published in the devkit, and will be executed for .json files in RFIX/RINT. These scripts will require at least python3.10. According to the readme in [GRAPHISOFT/archicad-addon-cmake](https://github.com/GRAPHISOFT/archicad-addon-cmake) the minimum version was 3.8 for the resource compilation script, but this was not indicated in CMake.

The localization of JSON resources is the same as well. The JSON resources are required to be in sync with the RINT/<AddonName>.xlf file. The devkit will contain the SyncXliff.py for this. The bilingual XLIFF files will need to be in a separate ResourceLibrary folder, similar to the Localization folder in perforce, this is the preferred way for the Localization team.

The permissive localization mode is still a question for me. During development we want to allow the localized XLIFF files not to be in sync with the INT one, but for builds that will be put in a release we don't want this to happen. For this reason I made it depend on the `AC_ADDON_FOR_DISTRIBUTION` variable for now.

There will be a solution in a follow up PR for converting the JSON resources back to GRC during build, which will not require us to maintain both GRC and JSON resources for addons which need to be compiled to <AC30 and AC30 from the same source.