### PR TITLE
Parallel build on Windows

### DIFF
--- a/CMakeCommon.cmake
+++ b/CMakeCommon.cmake
@@ -1,3 +1,5 @@
+set (CMAKE_VS_GLOBALS UseMultiToolTask=true EnforceProcessCountAcrossBuilds=true)
+
 function (SetGlobalCompilerDefinitions acVersion)
 
     if (WIN32)
@@ -28,7 +30,6 @@ function (SetCompilerOptions target acVersion)
             /Zc:wchar_t-
             /wd4499
             /EHsc
-            /MP
             -D_CRT_SECURE_NO_WARNINGS
         )
     else ()

--- a/CMakeCommon.cmake
+++ b/CMakeCommon.cmake
@@ -28,6 +28,7 @@ function (SetCompilerOptions target acVersion)
             /Zc:wchar_t-
             /wd4499
             /EHsc
+            /MP
             -D_CRT_SECURE_NO_WARNINGS
         )
     else ()


### PR DESCRIPTION
Currently the build on Windows uses one only one process at a time. As an example, the last addon I worked on with 70+ source files took me around 2 minutes to build. With this flag the this only takes 20 seconds. I have been using this locally over the past few weeks with no issues.

The Mac build seems to be already parallel, it uses all of my cores.