### PR TITLE
Update minimum Python3 version to 3.10

### DIFF
--- a/CMakeCommon.cmake
+++ b/CMakeCommon.cmake
@@ -227,12 +227,7 @@ function (GenerateAddOnProject target acVersion devKitDir addOnSourcesFolder add
         ${addOnResourcesFolder}/ResourceLibrary/*/XLF/${addOnName}.xlf
     )
 
-    set (minimumPython3Version "3.8")
-    if (NOT AddOnJSONResourceFiles STREQUAL "")
-        set (minimumPython3Version "3.10")
-    endif ()
-
-    find_package (Python3 ${minimumPython3Version} REQUIRED COMPONENTS Interpreter)
+    find_package (Python3 3.10 REQUIRED COMPONENTS Interpreter)
 
     message (STATUS "Using Python3 interpreter: ${Python3_EXECUTABLE}")
 


### PR DESCRIPTION
I already raised the minimum python3 version in the archicad-addon-cmake repo in https://github.com/GRAPHISOFT/archicad-addon-cmake/pull/49, but forgot to do it here. The JSON-to-GRC converter uses 3.10 features, so this must be the minimum regardless of JSON resources.