### PR TITLE
Fix "Translation" in VersionInfo to be consistent with winLangCharset

### DIFF
--- a/BuildAddOn.py
+++ b/BuildAddOn.py
@@ -221,7 +221,11 @@ def GetProjectGenerationParams (args, workspaceRootFolder, buildPath, platformNa
         winLangCharset = '040904b0'
         if languageCode != 'INT':
             winLangCharset = localizationMappingTable.get (languageCode, winLangCharset)
+        winLanguageId = int(winLangCharset[:4], 16)
+        winCharsetId = int(winLangCharset[4:], 16)
         projGenParams.append (f'-DAC_WIN_LANGCHARSET={winLangCharset}')
+        projGenParams.append (f'-DAC_WIN_LANGUAGEID={winLanguageId}')
+        projGenParams.append (f'-DAC_WIN_CHARSETID={winCharsetId}')
     elif platformName == 'MAC':
         projGenParams.append ('-GXcode')
 

--- a/CMakeCommon.cmake
+++ b/CMakeCommon.cmake
@@ -156,6 +156,8 @@ function (generate_add_on_version_info addOnLanguage outSemver)
         endif ()
 
         set (winLangCharset "${AC_WIN_LANGCHARSET}")
+        set (winLanguageId "${AC_WIN_LANGUAGEID}")
+        set (winCharsetId "${AC_WIN_CHARSETID}")
 
         foreach (res IN ITEMS VersionInfo AddOn)
             set (out "${CMAKE_CURRENT_BINARY_DIR}/${target}-${res}.rc")

--- a/VersionInfo.rc.in
+++ b/VersionInfo.rc.in
@@ -49,6 +49,6 @@ BEGIN
     /* https://learn.microsoft.com/en-us/windows/win32/menurc/varfileinfo-block */
     BLOCK "VarFileInfo"
     BEGIN
-        VALUE "Translation", 0x0409, 1200
+        VALUE "Translation", @winLanguageId@, @winCharsetId@
     END
 END


### PR DESCRIPTION
[ACP-24545](https://nemetschekprime.atlassian.net/browse/ACP-24545)

Set "Translation" to winLanguage and winCharset in "VarFileInfo" block to be consistent with "@winLangCharset@" block