### PR TITLE
Fix: ACP-24902 Cannot validate github-hosted localized add-ons on Macintosh

### DIFF
--- a/AddOnInfo.plist.in
+++ b/AddOnInfo.plist.in
@@ -20,7 +20,7 @@
 		<key>LSMinimumSystemVersion</key>
 		<string>@lsMinimumSystemVersion@</string>
 		<key>CFBundleDevelopmentRegion</key>
-		<string>en-US</string>
+		<string>@addOnRegion@</string>
 		<key>CFBundleIconFile</key>
 		<string>ArchiCADPlugin</string>
 		<key>CFBundleExecutable</key>

--- a/BuildAddOn.py
+++ b/BuildAddOn.py
@@ -86,7 +86,7 @@ def PrepareParameters (args):
     if args.buildConfig:
         buildConfigList = args.buildConfig
     else:
-        buildConfigList = ['RelWithDebInfo']    
+        buildConfigList = ['RelWithDebInfo']
 
     # Get needed language codes
     languageList = [configData['defaultLanguage'].upper ()]
@@ -228,6 +228,9 @@ def GetProjectGenerationParams (args, workspaceRootFolder, buildPath, platformNa
         projGenParams.append (f'-DAC_WIN_CHARSETID={winCharsetId}')
     elif platformName == 'MAC':
         projGenParams.append ('-GXcode')
+        localizationMappingTable = FillLocalizationMappingTable (devkitDir)
+        addOnRegion = localizationMappingTable.get (languageCode, 'English')
+        projGenParams.append (f'-DAC_ADDON_REGION={addOnRegion}')
 
     projGenParams.append (f'-DAC_VERSION={version}')
     projGenParams.append (f'-DAC_API_DEVKIT_DIR={str (devkitDir)}')

--- a/CMakeCommon.cmake
+++ b/CMakeCommon.cmake
@@ -199,6 +199,12 @@ function (generate_add_on_version_info addOnLanguage outSemver)
         string (REGEX REPLACE "[ _]" "-" addOnNameIdentifier "${lowerAddOnName}")
         set (bundleIdentifier "com.graphisoft.${addOnNameIdentifier}")
 
+        if (DEFINED AC_ADDON_REGION AND NOT AC_ADDON_REGION STREQUAL "")
+            set (addOnRegion "${AC_ADDON_REGION}")
+        else ()
+            set (addOnRegion "English")
+        endif ()
+
         set (out "${CMAKE_CURRENT_BINARY_DIR}/AddOnInfo.plist")
         configure_file ("${CMAKE_CURRENT_FUNCTION_LIST_DIR}/AddOnInfo.plist.in" "${out}" @ONLY)
         set_target_properties (

--- a/CompileResources.py
+++ b/CompileResources.py
@@ -29,7 +29,6 @@ class ResourceCompiler (object):
         self.permissiveLocalization = permissiveLocalization
         self.resConvPath = None
         self.nativeResourceFileExtension = None
-        self.localizationMappingTable = FillLocalizationMappingTable (devKitPath)
 
     def GetPlatformDevKitLinkKey (self) -> str:
         return ""
@@ -335,6 +334,7 @@ class MacResourceCompiler (ResourceCompiler):
             sourcesPath, resourcesPath, resourceObjectsPath, permissiveLocalization)
         self.resConvPath = devKitPath / 'Tools' / 'OSX' / 'ResConv'
         self.nativeResourceFileExtension = '.ro'
+        self.localizationMappingTable = FillLocalizationMappingTable (devKitPath)
         self.generatedFileNames = set ()
 
     def GetPlatformDevKitLinkKey(self) -> str:

--- a/CompileResources.py
+++ b/CompileResources.py
@@ -335,7 +335,7 @@ class MacResourceCompiler (ResourceCompiler):
         self.resConvPath = devKitPath / 'Tools' / 'OSX' / 'ResConv'
         self.nativeResourceFileExtension = '.ro'
         self.localizationMappingTable = FillLocalizationMappingTable (devKitPath)
-        self.generatedFileNames = set ()
+        self.generatedFixFileNames = set ()
 
     def GetPlatformDevKitLinkKey(self) -> str:
         return "MAC"
@@ -369,7 +369,7 @@ class MacResourceCompiler (ResourceCompiler):
                 for match in re.finditer (r"'([A-Za-z0-9]{4})'\s+(\d+)", f.read ()):
                     resId = match.group (1)
                     resNum = match.group (2)
-                    self.generatedFileNames.add (f'{resId}_{resNum}.rsrd')
+                    self.generatedFixFileNames.add (f'{resId}_{resNum}.rsrd')
 
         resConvResult = self.RunResConv ('M', 'utf16', precompiledGrcFilePath)
 
@@ -388,7 +388,7 @@ class MacResourceCompiler (ResourceCompiler):
             if extension == '.tif':
                 shutil.copy (filePath, resultResourcePath)
             elif extension == '.rsrd':
-                if filePath.name in self.generatedFileNames:
+                if filePath.name in self.generatedFixFileNames:
                     shutil.copy (filePath, resultResourcePath)
                 else:
                     shutil.copy (filePath, resultLocalizedResourcePath)

--- a/CompileResources.py
+++ b/CompileResources.py
@@ -91,7 +91,7 @@ class ResourceCompiler (object):
         with open (outputGrcFile, 'w', encoding='utf-8') as f:
             f.write (grcContent)
 
-        assert self.CompileGRCResourceFile (outputGrcFile), f'GRC compilation command failed: {outputGrcFile}'
+        assert self.CompileGRCResourceFile (outputGrcFile, localized), f'GRC compilation command failed: {outputGrcFile}'
 
     def CompileJSONResourceFile (self, jsonFilePath: Path, localized: bool) -> None:
         jsonResourceProcessorPath = self.devKitPath / 'Tools' / 'JSONResourceProcessor'
@@ -210,7 +210,7 @@ class ResourceCompiler (object):
         locResourcesFolder = self.resourcesPath / f'R{self.languageCode}'
         grcFiles = locResourcesFolder.glob ('*.grc')
         for grcFilePath in grcFiles:
-            assert self.CompileGRCResourceFile (grcFilePath), f'Failed to compile resource: {grcFilePath}'
+            assert self.CompileGRCResourceFile (grcFilePath, localized=True), f'Failed to compile resource: {grcFilePath}'
 
         locResourcesFolderDefault = self.resourcesPath / f'R{self.defaultLanguageCode}'
         jsonFiles = locResourcesFolderDefault.glob ('*.json')
@@ -223,7 +223,7 @@ class ResourceCompiler (object):
         fixResourcesFolder = self.resourcesPath / 'RFIX'
         grcFiles = fixResourcesFolder.glob ('*.grc')
         for grcFilePath in grcFiles:
-            assert self.CompileGRCResourceFile (grcFilePath), f'Failed to compile resource: {grcFilePath}'
+            assert self.CompileGRCResourceFile (grcFilePath, localized=False), f'Failed to compile resource: {grcFilePath}'
 
         jsonFiles = fixResourcesFolder.glob ('*.json')
         for jsonFilePath in jsonFiles:
@@ -290,7 +290,7 @@ class WinResourceCompiler (ResourceCompiler):
         assert result == 0, f'Failed to precompile resource {grcFilePath}'
         return precompiledGrcFilePath
 
-    def CompileGRCResourceFile (self, grcFilePath: Path) -> bool:
+    def CompileGRCResourceFile (self, grcFilePath: Path, localized: bool) -> bool:
         precompiledGrcFilePath = self.PrecompileGRCResourceFile (grcFilePath)
         return self.RunResConv ('W', '1252', precompiledGrcFilePath)
 
@@ -335,6 +335,7 @@ class MacResourceCompiler (ResourceCompiler):
             sourcesPath, resourcesPath, resourceObjectsPath, permissiveLocalization)
         self.resConvPath = devKitPath / 'Tools' / 'OSX' / 'ResConv'
         self.nativeResourceFileExtension = '.ro'
+        self.generatedFileNames = set ()
 
     def GetPlatformDevKitLinkKey(self) -> str:
         return "MAC"
@@ -360,9 +361,19 @@ class MacResourceCompiler (ResourceCompiler):
         assert result == 0, f'Failed to precompile resource {grcFilePath}'
         return precompiledGrcFilePath
 
-    def CompileGRCResourceFile (self, grcFilePath: Path) -> bool:
+    def CompileGRCResourceFile (self, grcFilePath: Path, localized: bool) -> bool:
         precompiledGrcFilePath = self.PrecompileGRCResourceFile (grcFilePath)
-        return self.RunResConv ('M', 'utf16', precompiledGrcFilePath)
+
+        if not localized:
+            with open (precompiledGrcFilePath, 'r', encoding='utf-8') as f:
+                for match in re.finditer (r"'([A-Za-z0-9]{4})'\s+(\d+)", f.read ()):
+                    resId = match.group (1)
+                    resNum = match.group (2)
+                    self.generatedFileNames.add (f'{resId}_{resNum}.rsrd')
+
+        resConvResult = self.RunResConv ('M', 'utf16', precompiledGrcFilePath)
+
+        return resConvResult
 
     def CompileNativeResource (self, resultResourcePath: Path) -> None:
         region_name = self.localizationMappingTable.get (self.languageCode, 'English')
@@ -377,7 +388,10 @@ class MacResourceCompiler (ResourceCompiler):
             if extension == '.tif':
                 shutil.copy (filePath, resultResourcePath)
             elif extension == '.rsrd':
-                shutil.copy (filePath, resultLocalizedResourcePath)
+                if filePath.name in self.generatedFileNames:
+                    shutil.copy (filePath, resultResourcePath)
+                else:
+                    shutil.copy (filePath, resultLocalizedResourcePath)
             elif extension == '.strings':
                 stringsFile = codecs.open (filePath, 'r', 'utf-16')
                 resultLocalizableStringsFile.write (stringsFile.read ())

--- a/LocalizationMappingTable.py
+++ b/LocalizationMappingTable.py
@@ -9,14 +9,14 @@ def FillLocalizationMappingTable (devKitPath: Path) -> dict[str, str]:
     system = platform.system ()
     if system == 'Windows':
         pattern = r'#define\s+VERSION_APPENDIX\s+"([A-Z]+)"[\s\S]*?#define\s+WIN_LANGCHARSET_STR\s+"([^"]+)"'
-    elif  system == 'Darwin':
+    elif system == 'Darwin':
         pattern = r'#define\s+VERSION_APPENDIX\s+"([A-Z]+)"[\s\S]*?#define\s+MAC_REGION_NAME\s+"([^"]+)"'
-    
+
     assert pattern, 'Platform is not supported'
 
     gsLocalizationPath = devKitPath / 'Inc' / 'GSLocalization.h'
-    with open(gsLocalizationPath, 'r', encoding='utf-8') as f:
+    with open (gsLocalizationPath, 'r', encoding='utf-8') as f:
         gsLocalizationContent = f.read ()
 
     patternRegex = re.compile (pattern, re.MULTILINE)
-    return { m.group(1): m.group(2) for m in patternRegex.finditer (gsLocalizationContent) }
+    return { m.group(1): m.group(2).replace ('_', '-') for m in patternRegex.finditer (gsLocalizationContent) }


### PR DESCRIPTION
This was caused by the recent changes to properly set the CFBundleDevelopmentRegion also to the add-on's language.

This can be easily done by creating the proper region name from the add-on's actual language.

Other changes:
- move the fix resources to the top level Resources folder from the language-specific .lproj folders
- FillLocalizationMappingTable was used only on macOS, so I moved it to MacResourceCompiler
- when creating the mapping table, the standard is to use the hyphenated version (this does not cause problems with Win charsets, because those only contain letters and numbers)