### PR TITLE
GSAI-1191 Create real folder structure for source files with filters

### DIFF
--- a/CMakeCommon.cmake
+++ b/CMakeCommon.cmake
@@ -338,7 +338,7 @@ function (GenerateAddOnProject target acVersion devKitDir addOnSourcesFolder add
     )
 
     # Mirror the source directory tree in VS Solution Explorer filters.
-    foreach (_sg_file ${AddOnHeaderFiles} ${AddOnSourceFiles} ${AddOnSrcJSONFiles})
+    foreach (file IN LISTS AddOnHeaderFiles AddOnSourceFiles AddOnSrcJSONFiles)
         file (RELATIVE_PATH _sg_rel "${CMAKE_SOURCE_DIR}/${addOnSourcesFolder}" "${_sg_file}")
         get_filename_component (_sg_dir "${_sg_rel}" DIRECTORY)
         if (_sg_dir)

--- a/CMakeCommon.cmake
+++ b/CMakeCommon.cmake
@@ -182,7 +182,7 @@ function (generate_add_on_version_info addOnLanguage outSemver)
         string (REPLACE < &lt\; addOnDescription "${addOnDescription}")
         string (REPLACE > &gt\; addOnDescription "${addOnDescription}")
         string (REPLACE ' &apos\; addOnDescription "${addOnDescription}")
-        string (REPLACE \" &quot\; addOnDescription "${addOnDescription}")
+        string (REPLACE "\"" "&quot;" addOnDescription "${addOnDescription}")
 
         set (privateBuild "\n\t\t<key>GSPrivateBuild</key>\n\t\t<string>1</string>")
         if (NOT AC_ADDON_FOR_DISTRIBUTION)

--- a/CMakeCommon.cmake
+++ b/CMakeCommon.cmake
@@ -322,10 +322,14 @@ function (GenerateAddOnProject target acVersion devKitDir addOnSourcesFolder add
         ${addOnSourcesFolder}/*.c
         ${addOnSourcesFolder}/*.cpp
     )
+    file (GLOB_RECURSE AddOnSrcJSONFiles CONFIGURE_DEPENDS
+        ${addOnSourcesFolder}/*.json
+    )
     set (
         AddOnFiles
         ${AddOnHeaderFiles}
         ${AddOnSourceFiles}
+        ${AddOnSrcJSONFiles}
         ${AddOnImageFiles}
         ${AddOnResourceFiles}
         ${AddOnJSONResourceFiles}
@@ -333,7 +337,17 @@ function (GenerateAddOnProject target acVersion devKitDir addOnSourcesFolder add
         ${ResourceStampFile}
     )
 
-    source_group ("Sources" FILES ${AddOnHeaderFiles} ${AddOnSourceFiles})
+    # Mirror the source directory tree in VS Solution Explorer filters.
+    foreach (_sg_file ${AddOnHeaderFiles} ${AddOnSourceFiles} ${AddOnSrcJSONFiles})
+        file (RELATIVE_PATH _sg_rel "${CMAKE_SOURCE_DIR}/${addOnSourcesFolder}" "${_sg_file}")
+        get_filename_component (_sg_dir "${_sg_rel}" DIRECTORY)
+        if (_sg_dir)
+            string (REPLACE "/" "\\" _sg_group "Sources\\${_sg_dir}")
+        else ()
+            set (_sg_group "Sources")
+        endif ()
+        source_group ("${_sg_group}" FILES "${_sg_file}")
+    endforeach ()
     source_group ("Images" FILES ${AddOnImageFiles})
     source_group ("Resources" FILES ${AddOnResourceFiles} ${AddOnJSONResourceFiles} ${AddOnXLIFFFiles})
     if (WIN32)

--- a/CMakeCommon.cmake
+++ b/CMakeCommon.cmake
@@ -338,16 +338,11 @@ function (GenerateAddOnProject target acVersion devKitDir addOnSourcesFolder add
     )
 
     # Mirror the source directory tree in VS Solution Explorer filters.
-    foreach (file IN LISTS AddOnHeaderFiles AddOnSourceFiles AddOnSrcJSONFiles)
-        file (RELATIVE_PATH _sg_rel "${PROJECT_SOURCE_DIR}/${addOnSourcesFolder}" "${file}")
-        get_filename_component (_sg_dir "${_sg_rel}" DIRECTORY)
-        if (_sg_dir)
-            string (REPLACE "/" "\\" _sg_group "Sources\\${_sg_dir}")
-        else ()
-            set (_sg_group "Sources")
-        endif ()
-        source_group ("${_sg_group}" FILES "${file}")
-    endforeach ()
+    source_group (
+        TREE "${PROJECT_SOURCE_DIR}/${addOnSourcesFolder}"
+        PREFIX "Sources"
+        FILES ${AddOnHeaderFiles} ${AddOnSourceFiles} ${AddOnSrcJSONFiles}
+    )
     source_group ("Images" FILES ${AddOnImageFiles})
     source_group ("Resources" FILES ${AddOnResourceFiles} ${AddOnJSONResourceFiles} ${AddOnXLIFFFiles})
     if (WIN32)

--- a/CMakeCommon.cmake
+++ b/CMakeCommon.cmake
@@ -339,14 +339,14 @@ function (GenerateAddOnProject target acVersion devKitDir addOnSourcesFolder add
 
     # Mirror the source directory tree in VS Solution Explorer filters.
     foreach (file IN LISTS AddOnHeaderFiles AddOnSourceFiles AddOnSrcJSONFiles)
-        file (RELATIVE_PATH _sg_rel "${CMAKE_SOURCE_DIR}/${addOnSourcesFolder}" "${_sg_file}")
+        file (RELATIVE_PATH _sg_rel "${PROJECT_SOURCE_DIR}/${addOnSourcesFolder}" "${file}")
         get_filename_component (_sg_dir "${_sg_rel}" DIRECTORY)
         if (_sg_dir)
             string (REPLACE "/" "\\" _sg_group "Sources\\${_sg_dir}")
         else ()
             set (_sg_group "Sources")
         endif ()
-        source_group ("${_sg_group}" FILES "${_sg_file}")
+        source_group ("${_sg_group}" FILES "${file}")
     endforeach ()
     source_group ("Images" FILES ${AddOnImageFiles})
     source_group ("Resources" FILES ${AddOnResourceFiles} ${AddOnJSONResourceFiles} ${AddOnXLIFFFiles})


### PR DESCRIPTION
Mirror source tree in VS filters and include JSON

Add recursive glob for .json source files and include them in AddOnFiles so JSON sources are part of the project. Replace the single flat "Sources" source_group with per-file source_group entries that compute each file's relative path under the add-on sources folder and create matching VS Solution Explorer filter groups, preserving the directory tree. Use CONFIGURE_DEPENDS for the GLOB_RECURSE so changes to JSON files are picked up during configuration.