### PR TITLE
Apple recommendation: no-constant-cfstrings

### DIFF
--- a/CMakeCommon.cmake
+++ b/CMakeCommon.cmake
@@ -37,6 +37,7 @@ function (SetCompilerOptions target acVersion)
     else ()
         target_compile_options (${target} PUBLIC -Wall -Wextra -Werror
             -fvisibility=hidden
+            -fno-constant-cfstrings
             -Wno-multichar
             -Wno-ctor-dtor-privacy
             -Wno-invalid-offsetof


### PR DESCRIPTION
Based on Apple's recommendation we should set this flag for plugins (see DEF-27711).